### PR TITLE
Added Socket Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Test server from CLI: `zimmed-downloader$ npm run server`
 
 _Or if you have previously installed bunyan globally `$ npm i -g bunyan` you can use `zimmed-downloader$ npm run server-pretty`._
 
-It is recommended to use a utility for managing the node service, like pm2, for deployment stability.
+It is recommended to use a utility for managing the node service, like [pm2](https://github.com/Unitech/pm2 "pm2"), for deployment stability.
 
 ### Legal
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ To deploy, first install all the CLI requirements:
     aria2 - The download utility which utlizies multiple connections (beneficial for premium downloads).
 
 Test the following commands to make sure all packages were properly installed (you can use `$ which <cmd>`):
- - unbuffer
- - plowprobe
- - plowdown
- - aria2c
+- unbuffer
+- plowprobe
+- plowdown
+- aria2c
 
 Next install javascript dependencies: `zimmed-downloader$ npm i`
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Update configuration in `src/config.js` and `src/test-config.js`
 [Optional] Run unit tests: `zimmed-downloader$ npm test`
 
 Test server from CLI: `zimmed-downloader$ npm run server`
-_Or if you have previously installed bunyan globally `$ npm i -g bunyan` you can use `zimmed-downloader$ npm run server-pretty`.
+
+_Or if you have previously installed bunyan globally `$ npm i -g bunyan` you can use `zimmed-downloader$ npm run server-pretty`._
 
 It is recommended to use a utility for managing the node service, like pm2, for deployment stability.
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ Update configuration in `src/config.js` and `src/test-config.js`
 
 [Optional] Run unit tests: `zimmed-downloader$ npm test`
 
-#### Not yet ready for test -- no driver
-
 Test server from CLI: `zimmed-downloader$ npm run server`
+_Or if you have previously installed bunyan globally `$ npm i -g bunyan` you can use `zimmed-downloader$ npm run server-pretty`.
 
 It is recommended to use a utility for managing the node service, like pm2, for deployment stability.
 

--- a/app.js
+++ b/app.js
@@ -1,0 +1,3 @@
+const RunApp = require('./src');
+
+RunApp();

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "src/index.js",
   "scripts": {
     "test": "mocha '*/**/*.spec.js'",
-    "server": "node src/index.js"
+    "server": "node app.js",
+    "server-pretty": "npm run server | bunyan"
   },
   "author": "zimmed@zimmed.io",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,12 @@
     "bluebird": "^3.4.6",
     "bunyan": "^1.8.5",
     "command-exists": "^1.0.2",
+    "express": "^4.14.0",
+    "glob": "^7.1.1",
     "lodash": "^4.17.2",
     "mktemp": "^0.4.0",
     "node-rsa": "^0.4.2",
-    "rmdir": "^1.2.0"
+    "rmdir": "^1.2.0",
+    "socket.io": "^1.7.1"
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -6,10 +6,17 @@
  */
 module.exports = {
 
-    serverName: '*****',   // [✓] CHANGE THIS; must be a unique identifier for this server instance.
-                                    //      Be sure to name it something simple and easy to remember, because
-                                    //      you and shared users will need to select the server by this name
-                                    //      when sending download requests from the web client.
+    // Socket Server
+    server: {
+        name: '*****',   // [✓] CHANGE THIS; must be a unique identifier for this server instance.
+                         //      Be sure to name it something simple and easy to remember, because
+                         //      you and shared users will need to select the server by this name
+                         //      when sending download requests from the web client.
+        host: '0.0.0.0',
+        port: 6001,
+        eventPath: 'src/events'
+    },
+
 
     logger: {
         logLevel: 'debug', // [✓] Bunyan logger level. See bunyan node package readme for more info.

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,14 @@
-const DM = require('./manager');
-const Auth = require('./auth');
+const DownloadManager = require('./manager');
+const Server = require('./server');
+const logger = require('./logger');
+
+const main = module.exports = () => {
+    let model = DownloadManager.create(),
+        init = Server(model);
+
+    init().then(sm => {
+        logger.info(`Socket server listening at ${sm.host}:${sm.port}...`);
+    }).catch(e => {
+        logger.error(`Failed to start socket server: ${e}`);
+    });
+};

--- a/src/manager/index.js
+++ b/src/manager/index.js
@@ -15,7 +15,6 @@ const TEMP_DIR_MASK = 'dl-XXXXXXXX';
 const Manager = module.exports = {
 
     create: ({
-        id='singleManager',
         maxConcurrent=4,
         maxConnections=4,
         maxSpeed=0,
@@ -30,12 +29,6 @@ const Manager = module.exports = {
         onDLQueued=_.noop
     }={}) => {
         let m = Object.defineProperties({}, {
-            id: {
-                writable: false,
-                configurable: false,
-                enumerable: true,
-                value: id
-            },
             queue: {
                 writable: false,
                 configurable: false,

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,0 +1,10 @@
+const SocketManager = require('../util/socketmanager');
+const EventManager = require('../util/eventmanager');
+const Config = require('../config').server;
+
+module.exports = (model) => {
+    let em = EventManager.create(Config.eventPath),
+        sm = SocketManager.create(Config.name, Config.host, Config.port, model, em);
+
+    return () => sm.init();
+};

--- a/src/util/eventmanager/eventmanager.js
+++ b/src/util/eventmanager/eventmanager.js
@@ -1,0 +1,56 @@
+const _ = require('lodash');
+const glob = require('glob');
+const path = require('path');
+
+module.exports = {
+
+    register: function (eventName, eventHandler, id=null, em=this) {
+        if (!em.routes.hasOwnProperty(eventName)) {
+            em.routes[eventName] = [];
+        }
+        em.routes[eventName].push({handler: eventHandler, id});
+    },
+
+    deregister: function (eventName, id=null, em=this) {
+        if (em.routes.hasOwnProperty(eventName)) {
+            em.routes[eventName] = _.filter(em.routes[eventName], r => {
+                return id !== null && r.id !== id;
+            });
+        }
+    },
+
+    on: this.register,
+
+    off: this.deregister,
+
+    handle: function (eventName, eventData, model, self, em=this) {
+        if (em.routes.hasOwnProperty(eventName)) {
+            em.routes[eventName].forEach((r) => {
+                r.handler.apply(self, [model, eventData]);
+            });
+        } else {
+            throw new Error(`Uncaught event '${eventName}'`);
+        }
+    },
+
+    create: function (eventPath=false) {
+        let em = Object.defineProperties(Object.create(this), {
+            routes: {
+                value: {},
+                writable: false,
+                enumerable: false
+            }
+        });
+
+        if (eventPath) {
+            // Discover events
+            _.forEach(glob.sync(eventPath + '/**/*.event.js'), ef => {
+                let name = ef.substring(ef.lastIndexOf('/') + 1, ef.indexOf('.event.js'));
+                ef = path.relative(__dirname, ef);
+                em.register(name, require(`./${ef}`));
+            });
+        }
+
+        return em;
+    }
+};

--- a/src/util/eventmanager/eventmanager.spec.js
+++ b/src/util/eventmanager/eventmanager.spec.js
@@ -1,0 +1,47 @@
+const expect = require('chai').expect;
+const EventManager = require('./eventmanager');
+
+describe('The EventManager', () => {
+    it('should create', () => {
+        let emExample = EventManager.create();
+        expect(emExample).to.exist;
+        expect(emExample).to.have.property('handle');
+        expect(typeof(emExample.handle)).to.equal('function');
+        expect(emExample).to.have.property('register');
+        expect(typeof(emExample.register)).to.equal('function');
+        expect(emExample).to.have.property('routes');
+        expect(typeof(emExample.routes)).to.equal('object');
+    });
+    it('should register and resolve handlers', (done) => {
+        let game = {}, server = {}, client = {}, self = {client, server},
+            emExample = EventManager.create(),
+            eventAHandler = function (game, {arg1, arg2}={}) {
+                expect(arg1).to.equal(10);
+                expect(arg2).to.equal("ten");
+                expect(this).to.have.property('client');
+                expect(this).to.have.property('server');
+                expect(game).to.exist;
+                this._test_data = "expected";
+            },
+            eventAHandlerB = function () {
+                expect(this).to.have.property('_test_data');
+                expect(this._test_data).to.equal("expected");
+                this._test_data = '';
+            },
+            eventBHandler = function (game) {
+                expect(this.client).to.equal(client);
+                expect(this.server).to.equal(server);
+                expect(game).to.equal(game);
+                done();
+            };
+        emExample.register('event a', eventAHandler);
+        emExample.register('event a', eventAHandlerB, 'temp');
+        emExample.register('event b', eventBHandler);
+        emExample.handle('event a', {arg1: 10, arg2: 'ten'}, game, self);
+        expect(self._test_data).to.equal('');
+        emExample.deregister('event a', 'temp');
+        emExample.handle('event a', {arg1: 10, arg2: 'ten'}, game, self);
+        expect(self._test_data).to.equal('expected');
+        emExample.handle('event b', null, game, {client, server});
+    });
+});

--- a/src/util/eventmanager/index.js
+++ b/src/util/eventmanager/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./eventmanager');

--- a/src/util/socketmanager/index.js
+++ b/src/util/socketmanager/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./socket');

--- a/src/util/socketmanager/socket.js
+++ b/src/util/socketmanager/socket.js
@@ -1,0 +1,98 @@
+const express = require('express');
+const http = require('http');
+const _ = require('lodash');
+const io = require('socket.io');
+
+const SMRegistry = {};
+const httpServer = http.createServer(express());
+const ioServer = io(httpServer, {serveClient: false});
+
+const Socket = module.exports = {
+
+    get: name => {
+        return _.get(SMRegistry, name, null);
+    },
+
+    filter: function filter(client, sm=this) {
+        return Object.defineProperties({}, {
+            client: {
+                value: client,
+                writable: false,
+                enumerable: true
+            },
+            server: {
+                value: sm.connectionServer,
+                writable: false,
+                enumerable: true
+            },
+            group: {
+                value: sm.connectionGroup,
+                writable: false,
+                enumerable: true
+            }
+        });
+    },
+
+    init: function init(cb=_.noop, sm=this) {
+        sm.connectionGroup.on('connection', (client) => {
+            sm.eventManager.handle('connection', {}, sm.model, sm.filter(client));
+            Object.keys(sm.eventManager.routes).forEach((e) => {
+                if (e !== 'connection') {
+                    client.on(e, (data) => sm.eventManager.handle(e, data, sm.model, sm.filter(client)));
+                }
+            });
+        });
+        sm.httpServer.listen(sm.port, () => { cb(sm); });
+    },
+
+    create: function create(name, host, port, model, eventManager) {
+        if (SMRegistry.hasOwnProperty(name)) {
+            throw `Socket Manager for '${name}' is already defined.`;
+        }
+        SMRegistry[name] = Object.defineProperties(Object.create(this), {
+            model: {
+                value: model,
+                writable: true,
+                enumerable: false
+            },
+            host: {
+                value: host,
+                writable: false,
+                enumerable: true
+            },
+            port: {
+                value: port,
+                writable: false,
+                enumerable: true
+            },
+            name: {
+                value: name,
+                writable: false,
+                enumerable: true
+            },
+            httpServer: {
+                get: () => {
+                    return httpServer;
+                },
+                enumerable: false
+            },
+            connectionServer: {
+                get: () => {
+                    return ioServer;
+                },
+                enumerable: false
+            },
+            connectionGroup: {
+                value: ioServer.of('/' + name),
+                writable: false,
+                enumerable: false
+            },
+            eventManager: {
+                value: eventManager,
+                enumerable: false,
+                writable: false
+            }
+        });
+        return SMRegistry[name];
+    }
+};

--- a/src/util/socketmanager/socket.spec.js
+++ b/src/util/socketmanager/socket.spec.js
@@ -1,0 +1,21 @@
+const expect = require('chai').expect;
+const SocketManager = require('./socket');
+const EM = require('../eventmanager');
+
+describe('A SocketManager', () => {
+    it('should create', () => {
+        let game = {}, sm;
+        expect(SocketManager).to.have.property('create');
+        expect(SocketManager).to.have.property('get');
+        sm = SocketManager.create('ex1', 'localhost', 6001, game, EM.create());
+        expect(sm).to.exist;
+        expect(sm).to.have.property('eventManager');
+        expect(sm).to.have.property('connectionServer');
+        expect(sm).to.have.property('connectionGroup');
+        expect(sm).to.have.property('httpServer');
+        expect(sm).to.have.property('model');
+        expect(sm.model).to.equal(game);
+        game.prop = 'prop';
+        expect(sm.model).to.equal(game);
+    });
+});


### PR DESCRIPTION
Used previous (now un-hosted) node packages zimmed-eventmanager and zimmed-socketmanager, which for now, will reside under `src/util/eventmanager` and `src/util/socketmanager`.

Added localized implementation for socket-server in `src/server` module, and updated driver for app.